### PR TITLE
feat: commit to key and nonce in zkVM proof output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7592,4 +7592,5 @@ version = "0.1.0"
 dependencies = [
  "chacha20",
  "rand 0.9.1",
+ "sha2 0.10.8",
 ]

--- a/justfile
+++ b/justfile
@@ -3,6 +3,7 @@ default:
 
 alias r := run-debug
 alias rr := run-release
+alias bc := bench-cycles
 alias db := docker-build
 alias ds := docker-save
 alias dl := docker-load
@@ -33,6 +34,10 @@ _pre-build:
 
 _pre-run:
     echo "just pre-run TODO"
+
+# Check cycle counts for zkVM on ./zkVM/static example inputs
+bench-cycles *FLAGS: _pre-build _pre-run
+    cargo r -r -p sp1-util --bin cli -- --execute
 
 # Run in release mode, with optimizations AND debug logs
 run-release *FLAGS: _pre-build _pre-run

--- a/scripts/test_example_data_file_via_curl.sh
+++ b/scripts/test_example_data_file_via_curl.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# Helper to send a test file to the proxy with curl
+# WARN: Hard coded incorrect variables here otherwise!
+
+FILE="../zkVM/static/proof_input_example.bin"
+source ../.env
+{
+  echo -n '{ "id": 1, "jsonrpc": "2.0", "method": "blob.Submit", "params": [ [ { "namespace": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAMJ/xGlNMdE=", "data": "'
+  base64 -w0 "$FILE"
+  echo '", "share_version": 0, "commitment": "aHlbp+J9yub6hw/uhK6dP8hBLR2mFy78XNRRdLf2794=", "index": -1 } ], {} ] }'
+} | curl -H "Content-Type: application/json" -H "Authorization: Bearer $CELESTIA_NODE_WRITE_TOKEN" \
+         -X POST --data @- https://$PDA_SOCKET --verbose --insecure
+

--- a/service/src/internal/job.rs
+++ b/service/src/internal/job.rs
@@ -1,3 +1,5 @@
+use core::fmt;
+
 use crate::PdaRunnerError;
 
 use serde::{Deserialize, Serialize};
@@ -20,9 +22,9 @@ pub struct Input {
     pub data: Vec<u8>,
 }
 
-/// A committment to the input, likley a hash or related fingerprint.
+/// A commitment to the input, likely a hash or related fingerprint.
 /// TODO: what should structure be?
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Serialize, Deserialize, Clone)]
 pub struct Anchor {
     pub data: Vec<u8>,
 }
@@ -30,6 +32,15 @@ pub struct Anchor {
 impl AsRef<[u8]> for Anchor {
     fn as_ref(&self) -> &[u8] {
         self.data.as_slice()
+    }
+}
+
+impl fmt::Debug for Anchor {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let anchor_hex = bytes_to_hex(&self.data);
+        f.debug_struct("Anchor")
+            .field("data (hex)", &anchor_hex)
+            .finish()
     }
 }
 
@@ -60,4 +71,9 @@ impl std::fmt::Debug for JobStatus {
             JobStatus::Failed(_, _) => write!(f, "Failed"),
         }
     }
+}
+
+fn bytes_to_hex(bytes: &[u8]) -> String {
+    let digest_hex: String = bytes.iter().map(|b| format!("{:02x}", b)).collect();
+    digest_hex
 }

--- a/service/src/main.rs
+++ b/service/src/main.rs
@@ -289,7 +289,10 @@ pub async fn inbound_handler(
                             if let Some(proof_with_values) =
                                 pda_runner.get_verifiable_encryption(job).await?
                             {
-                                debug!("Replacing blob.data with: {proof_with_values:?}");
+                                debug!(
+                                    "Replacing blob.data with <Sp1ProofWithPublicValues>.proof = {:?}",
+                                    proof_with_values.proof
+                                );
 
                                 let encrypted_data = bincode::serialize(&proof_with_values)?;
                                 let encrypted_blob = Blob::new(

--- a/zkVM/common/Cargo.toml
+++ b/zkVM/common/Cargo.toml
@@ -5,10 +5,11 @@ edition.workspace = true
 
 [dependencies]
 chacha20.workspace = true
-rand = { version = "0.9", default-features = false, optional = true, features = [
+rand = { workspace = true, default-features = false, optional = true, features = [
   "os_rng",
 ] }
+sha2 = { workspace = true, optional = true }
 
 [features]
 default = ["std"]
-std = ["rand/os_rng"]
+std = ["rand/os_rng", "sha2"]

--- a/zkVM/common/src/lib.rs
+++ b/zkVM/common/src/lib.rs
@@ -64,7 +64,7 @@ pub mod std_only {
         }
     }
 
-    impl fmt::Debug for ZkvmOutput<'_> {
+    impl core::fmt::Debug for ZkvmOutput<'_> {
         fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
             let privkey_hash_hex = bytes_to_hex(&self.privkey_hash);
             let nonce_hex = bytes_to_hex(&self.nonce);

--- a/zkVM/common/src/lib.rs
+++ b/zkVM/common/src/lib.rs
@@ -4,6 +4,11 @@ pub const INPUT_BYTES: &[u8] = include_bytes!("../../static/proof_input_example.
 use chacha20::ChaCha20;
 use chacha20::cipher::{KeyIvInit, StreamCipher};
 
+pub const KEY_LEN: usize = 32;
+pub const HASH_LEN: usize = 32;
+pub const NONCE_LEN: usize = 12;
+pub const HEADER_LEN: usize = HASH_LEN + NONCE_LEN + HASH_LEN;
+
 /// Encrypt a buffer in-place using [ChaCha20](https://en.wikipedia.org/wiki/Salsa20#ChaCha_variant).
 ///
 /// ## Important Notice
@@ -13,26 +18,83 @@ use chacha20::cipher::{KeyIvInit, StreamCipher};
 /// man-in-the-middle manipulation of the ciphertext.
 /// A zkVM proving correct execution of this function provides these properties.
 ///
-pub fn chacha(key: &[u8; 32], nonce: &[u8; 12], buffer: &mut [u8]) {
+pub fn chacha(key: &[u8; KEY_LEN], nonce: &[u8; NONCE_LEN], buffer: &mut [u8]) {
     let mut cipher = ChaCha20::new(key.into(), nonce.into());
     cipher.apply_keystream(buffer);
 }
 
-// Helper to format bytes as hex for pretty printing
-pub fn bytes_to_hex(bytes: &[u8]) -> String {
-    let digest_hex: String = bytes.iter().map(|b| format!("{:02x}", b)).collect();
-    digest_hex
-}
-
 // Only compile this when the standard library is available
 #[cfg(feature = "std")]
-mod std_only {
+pub mod std_only {
+    use super::*;
+    use core::fmt;
     use rand::{TryRngCore, rngs::OsRng};
+    use sha2::{Digest, Sha256};
 
-    pub fn random_nonce() -> [u8; 12] {
-        let mut nonce = [0u8; 12];
+    pub struct ZkvmOutput<'a> {
+        pub privkey_hash: [u8; HASH_LEN],
+        pub nonce: [u8; NONCE_LEN],
+        pub plaintext_hash: [u8; HASH_LEN],
+        pub ciphertext: &'a [u8],
+    }
+
+    impl<'a> ZkvmOutput<'a> {
+        pub fn from_bytes(data: &'a [u8]) -> Result<Self, &'static str> {
+            if data.len() < HEADER_LEN {
+                return Err("Input too short for header");
+            }
+
+            let (header, ciphertext) = data.split_at(HEADER_LEN);
+
+            let mut privkey_hash = [0u8; HASH_LEN];
+            privkey_hash.copy_from_slice(&header[..HASH_LEN]);
+
+            let mut nonce = [0u8; NONCE_LEN];
+            nonce.copy_from_slice(&header[HASH_LEN..HASH_LEN + NONCE_LEN]);
+
+            let mut plaintext_hash = [0u8; HASH_LEN];
+            plaintext_hash.copy_from_slice(&header[HASH_LEN + NONCE_LEN..HEADER_LEN]);
+
+            Ok(ZkvmOutput {
+                privkey_hash,
+                nonce,
+                plaintext_hash,
+                ciphertext,
+            })
+        }
+    }
+
+    impl fmt::Debug for ZkvmOutput<'_> {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            let privkey_hash_hex = bytes_to_hex(&self.privkey_hash);
+            let nonce_hex = bytes_to_hex(&self.nonce);
+            let plaintext_hash_hex = bytes_to_hex(&self.plaintext_hash);
+
+            let mut hasher = Sha256::new();
+            hasher.update(self.ciphertext);
+            let ciphertext_hash = hasher.finalize();
+            let ciphertext_hash_hex = bytes_to_hex(&ciphertext_hash);
+
+            f.debug_struct("ZkvmOutput")
+                .field("privkey_hash", &privkey_hash_hex)
+                .field("nonce", &nonce_hex)
+                .field("plaintext_hash", &plaintext_hash_hex)
+                .field("ciphertext_sha256", &ciphertext_hash_hex)
+                .finish()
+        }
+    }
+
+    // Helper to get a OsRng nonce of correct length
+    pub fn random_nonce() -> [u8; NONCE_LEN] {
+        let mut nonce = [0u8; NONCE_LEN];
         OsRng.try_fill_bytes(&mut nonce).expect("Rng->buffer");
         nonce
+    }
+
+    // Helper to format bytes as hex for pretty printing
+    pub fn bytes_to_hex(bytes: &[u8]) -> String {
+        let digest_hex: String = bytes.iter().map(|b| format!("{:02x}", b)).collect();
+        digest_hex
     }
 }
 

--- a/zkVM/sp1/program-chacha/src/main.rs
+++ b/zkVM/sp1/program-chacha/src/main.rs
@@ -3,13 +3,24 @@ sp1_zkvm::entrypoint!(main);
 
 use sha2::{Digest, Sha256};
 
-use zkvm_common::chacha;
+use zkvm_common::{chacha, NONCE_LEN};
 
 pub fn main() {
     let key = sp1_zkvm::io::read_vec(); // 32 bytes
     let nonce = sp1_zkvm::io::read_vec(); // 12 bytes
     // The plaintext to be encrypted _in place_
-    let mut buffer = sp1_zkvm::io::read_vec(); // 12 bytes
+    let mut buffer = sp1_zkvm::io::read_vec(); // ~1M bytes
+
+    // Commit to key used, providing a fixed UID as first bytes in proof data.
+    // So now we have a tag we can look for in filtering DA data latter.
+    let key_hash = Sha256::digest(key.as_slice());
+    sp1_zkvm::io::commit_slice(&key_hash); // 32 bytes
+
+    // Commit to nonce used, this is safe so long as we NEVER reuse a nonce!
+    // NOTE: without reading nonce in the next line, it is optimized out or unread = zeros
+    // So for a few cycles we ensure it's not dropped also enforce it's the right length
+    let nonce: [u8; NONCE_LEN] = nonce.try_into().expect("nonce=12B");
+    sp1_zkvm::io::commit_slice(&nonce);
 
     // Commit to buffer (plaintext) hash
     //
@@ -24,16 +35,13 @@ pub fn main() {
     // Hash plaintext & commit
     sp1_zkvm::io::commit_slice(&plaintext_hash); // 32 bytes
 
-    // FIXME // TODO:
-    // Hash key and/or nonce & commit?
-
     // Encrypt and commit
     // Incorrect sized buffers passed in are unacceptable, and thus panic.
     chacha(
         &key.try_into().expect("key=32B"),
-        &nonce.try_into().expect("nonce=12B"),
+        &nonce,
         &mut buffer,
     );
 
-    sp1_zkvm::io::commit_slice(&buffer);
+    sp1_zkvm::io::commit_slice(&buffer); // ~1M bytes
 }

--- a/zkVM/sp1/program-chacha/src/main.rs
+++ b/zkVM/sp1/program-chacha/src/main.rs
@@ -3,7 +3,7 @@ sp1_zkvm::entrypoint!(main);
 
 use sha2::{Digest, Sha256};
 
-use zkvm_common::{chacha, NONCE_LEN};
+use zkvm_common::{NONCE_LEN, chacha};
 
 pub fn main() {
     let key = sp1_zkvm::io::read_vec(); // 32 bytes
@@ -37,11 +37,7 @@ pub fn main() {
 
     // Encrypt and commit
     // Incorrect sized buffers passed in are unacceptable, and thus panic.
-    chacha(
-        &key.try_into().expect("key=32B"),
-        &nonce,
-        &mut buffer,
-    );
+    chacha(&key.try_into().expect("key=32B"), &nonce, &mut buffer);
 
     sp1_zkvm::io::commit_slice(&buffer); // ~1M bytes
 }

--- a/zkVM/sp1/src/bin/cli.rs
+++ b/zkVM/sp1/src/bin/cli.rs
@@ -3,7 +3,7 @@ use hex::FromHex;
 use sha2::{Digest, Sha256};
 use sp1_sdk::{ProverClient, SP1Stdin, include_elf};
 
-use zkvm_common::chacha;
+use zkvm_common::{chacha, std_only::ZkvmOutput, KEY_LEN, NONCE_LEN};
 
 /// The ELF (executable and linkable format) file for the Succinct RISC-V zkVM.
 pub const CHACHA_ELF: &[u8] = include_elf!("chacha-program");
@@ -41,14 +41,19 @@ fn main() {
     // - nonce = 12 bytes (MUST BE UNIQUE - NO REUSE!)
     // - input_plaintext = bytes to encrypt
 
-    let key = <[u8; 32]>::from_hex(
+    let input_key = <[u8; KEY_LEN]>::from_hex(
         std::env::var("ENCRYPTION_KEY").expect("Missing ENCRYPTION_KEY env var"),
     )
-    .expect("ENCRYPTION_KEY must be 32 bytes, hex encoded (ex: `1234...abcd`)");
-    stdin.write_slice(&key);
+    .unwrap_or_else(|_| {
+        panic!(
+            "ENCRYPTION_KEY must be {} bytes, hex encoded (ex: `1234...abcd`)",
+            KEY_LEN
+        )
+    });
+    stdin.write_slice(&input_key);
 
-    let nonce: [u8; 12] = zkvm_common::random_nonce();
-    stdin.write_slice(&nonce);
+    let input_nonce: [u8; NONCE_LEN] = zkvm_common::random_nonce();
+    stdin.write_slice(&input_nonce);
 
     // TODO: replace example bytes with service interface
     let input_plaintext: &[u8] = zkvm_common::INPUT_BYTES;
@@ -57,39 +62,35 @@ fn main() {
     let client = ProverClient::from_env();
     if args.execute {
         // Execute the program
-        let (output, report) = client.execute(CHACHA_ELF, &stdin).run().unwrap();
-        println!("Program executed successfully.");
+        let (output_buffer, report) = client.execute(CHACHA_ELF, &stdin).run().unwrap();
 
         // Read the output.
-        // - sha2 hash = 32 bytes
-        // - ciphertext = encrypted bytes
-        let output = output.to_vec();
-        let (output_hash_plaintext, output_ciphertext) = output.split_at(32);
+        // - privkey sha2 hash = 32 bytes
+        // - nonce = 12 bytes
+        // - plaintext sha2 hash = 32 bytes
+        // - ciphertext = encrypted bytes, ~1M bytes
+        let output =
+            ZkvmOutput::from_bytes(output_buffer.as_slice()).expect("Failed to parse header");
 
         // Check against the input
         let input_plaintext_digest = Sha256::digest(input_plaintext);
         println!(
             "Input -> plaintext hash: 0x{}",
-            zkvm_common::bytes_to_hex(&input_plaintext_digest)
+            zkvm_common::std_only::bytes_to_hex(&input_plaintext_digest)
         );
-        println!(
-            "zkVM -> plaintext hash: 0x{}",
-            zkvm_common::bytes_to_hex(output_hash_plaintext)
-        );
+        dbg!(&output);
 
-        let ciphertext_digest = Sha256::digest(output_ciphertext);
-        println!(
-            "zkVM -> ciphertext hash: 0x{}",
-            zkvm_common::bytes_to_hex(&ciphertext_digest)
-        );
-
+        assert_eq!(input_nonce, output.nonce);
         // NOTE: stream cipher is decrypted by running the chacha encryption again.
         // (plaintext XOR keystream XOR keystream = plaintext; QED)
-        let mut output_plaintext = output_ciphertext.to_owned();
-        chacha(&key, &nonce, &mut output_plaintext);
+        let mut output_plaintext = output.ciphertext.to_owned();
+        chacha(&input_key, &output.nonce, &mut output_plaintext);
 
         assert_eq!(output_plaintext, input_plaintext);
         println!("Decryption of zkVM ciphertext matches input!");
+        let input_key_hash = Sha256::digest(input_key);
+        assert_eq!(input_key_hash.as_slice(), output.privkey_hash);
+        println!("Key used matched!");
 
         // Record the number of cycles executed.
         println!("Number of cycles: {}", report.total_instruction_count());

--- a/zkVM/sp1/src/bin/cli.rs
+++ b/zkVM/sp1/src/bin/cli.rs
@@ -3,7 +3,7 @@ use hex::FromHex;
 use sha2::{Digest, Sha256};
 use sp1_sdk::{ProverClient, SP1Stdin, include_elf};
 
-use zkvm_common::{chacha, std_only::ZkvmOutput, KEY_LEN, NONCE_LEN};
+use zkvm_common::{KEY_LEN, NONCE_LEN, chacha, std_only::ZkvmOutput};
 
 /// The ELF (executable and linkable format) file for the Succinct RISC-V zkVM.
 pub const CHACHA_ELF: &[u8] = include_elf!("chacha-program");


### PR DESCRIPTION
Previously there was not enough info in the proof to verify the correct encryption, this PR adds:

- A SHA2_256 hash of the key used (also acts as a UID to filter on DA, as it prepends all data submitted to the DA)
- The nonce (12 bytes, _MUST_ not be reused! We get this from `OsRng` presently

Also added helper structs and fns. Note that we don't use serde at the zkVM<>host interface to keep cycles minimal.

### Cycle stats

`just bc` runs:

| commit | # of cycles | note |
|---|---|---|
| e58c0d8 | 76215990 | before this PR |
| 5aaffb6 | 76216976 | only minimal hash & commit from program |
| TBD | ? | use smarter chunked hash & encrypt to better use pages ([see suggestion here](https://chatgpt.com/c/68139865-bdb4-8001-93e4-94fbbf188204)) |