### PR TITLE
enable env to set FulfilmentStrategy for network provers

### DIFF
--- a/example.env
+++ b/example.env
@@ -71,6 +71,10 @@ SP1_PROVER=cuda
 # TODO: This feature is NOT fully implemented! We need a TEE wrapper around proving remote for this.
 NETWORK_RPC_URL=https://rpc.production.succinct.xyz
 NETWORK_PRIVATE_KEY=
+# Strategy one of "UNSPECIFIED_FULFILLMENT_STRATEGY", "HOSTED", "RESERVED", "AUCTION"
+# You likely want HOSTED (the hardcoded default for network provers)
+# https://github.com/succinctlabs/sp1/blob/11ab6b783cfce295b6f1113af088cc5f0a8caa5b/crates/sdk/src/network/prover.rs#L138
+SP1_FULFILLMENT_STRATEGY=HOSTED
 
 #### Dependent & Provider Settings
 
@@ -87,8 +91,4 @@ CELESTIA_NODE_TYPE=light
 CELESTIA_NODE_NAME=celestia-light-mocha-4
 CELESTIA_DATA_DIR=/home/you/.celestia-light-mocha-4
 CELESTIA_NODE_WRITE_TOKEN=
-
-
-
-
 

--- a/justfile
+++ b/justfile
@@ -140,9 +140,11 @@ celestia-node-balance:
 
 # Test blob.Get for PDA Proxy
 curl-blob-get:
-    curl -H "Content-Type: application/json" -H "Authorization: Bearer $CELESTIA_NODE_WRITE_TOKEN" --data '{"id": 1,"jsonrpc": "2.0", "method": "blob.Get", "params": [ 42, "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAMJ/xGlNMdE=", "aHlbp+J9yub6hw/uhK6dP8hBLR2mFy78XNRRdLf2794=" ] }' \
+    curl -H "Content-Type: application/json" -H "Authorization: Bearer $CELESTIA_NODE_WRITE_TOKEN" --data '{"id": 1,"jsonrpc": "2.0", "method": "blob.Get", "params": [ 6608695, "AAAAAAAAAAAAAAAAAAAAAAAAAAvBBshVQcTi92w=", "nPDyRXefks+koMJhy7LzN9269+Oz4PjcsAPk64ke85E=" ] }' \
     https://127.0.0.1:26657 \
     --insecure | jq
+
+# https://mocha.celenium.io/tx/436f223bfa8c4adf1e1b79dde43a84918f3a50809583c57c33c1c079568b47cb?tab=messages
 
 # Test blob.Submit for PDA proxy
 curl-blob-submit:

--- a/service/src/internal/runner.rs
+++ b/service/src/internal/runner.rs
@@ -6,7 +6,8 @@ use sha2::Digest;
 use sled::{Transactional, Tree as SledTree};
 use sp1_sdk::{
     EnvProver as SP1EnvProver, NetworkProver as SP1NetworkProver, Prover, SP1ProofWithPublicValues,
-    SP1Stdin, network::Error as SP1NetworkError,
+    SP1Stdin,
+    network::{Error as SP1NetworkError, FulfillmentStrategy},
 };
 use std::sync::Arc;
 use tokio::sync::{OnceCell, mpsc};
@@ -513,6 +514,12 @@ impl PdaRunner {
             .get_proof_setup_remote(program_id, zk_client_handle.clone())
             .await?;
 
+        let fs_string = std::env::var("SP1_FULFILLMENT_STRATEGY")
+            .expect("Missing SP1_FULFILLMENT_STRATEGY env var");
+        let strategy = FulfillmentStrategy::from_str_name(fs_string.as_str()).ok_or(
+            PdaRunnerError::InternalError("SP1_FULFILLMENT_STRATEGY env var malformed".to_string()),
+        )?;
+
         let mut stdin = SP1Stdin::new();
         // Setup the inputs:
         // - key = 32 bytes
@@ -536,6 +543,7 @@ impl PdaRunner {
         debug!("0x{} - Starting proof", hex::encode(job_key));
         let request_id: util::SuccNetJobId = zk_client_handle
             .prove(&proof_setup.pk, &stdin)
+            .strategy(strategy)
             .groth16()
             .skip_simulation(false)
             .timeout(std::time::Duration::from_secs(5)) // Don't hang too long on this. If it's gonna fail, fail fast.


### PR DESCRIPTION
adds a new env var to set the kind of https://docs.rs/sp1-sdk/latest/sp1_sdk/network/proto/network/enum.FulfillmentStrategy.html you want to use with sp1 network provers  