### PR TITLE
Reproducible ELF builds for SP1 program in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,9 @@
 FROM nvidia/cuda:12.9.1-devel-ubuntu24.04 AS base-dev
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive \
-  apt-get install --no-install-recommends -y \
-  clang libclang-dev docker.io curl tar build-essential pkg-config git ca-certificates gnupg2 \
-  && rm -rf /var/lib/apt/lists/*
+    apt-get install --no-install-recommends -y \
+    clang libclang-dev docker.io curl tar build-essential pkg-config git ca-certificates gnupg2 \
+    && rm -rf /var/lib/apt/lists/*
  
 ENV GO_VERSION=1.24.4
 ENV GO_URL="https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz"
@@ -26,7 +26,7 @@ RUN cargo install cargo-chef
 
 # https://docs.succinct.xyz/docs/sp1/getting-started/install
 RUN curl -L https://sp1up.succinct.xyz | bash && \
-  /root/.sp1/bin/sp1up
+    /root/.sp1/bin/sp1up
 
 ####################################################################################################
 FROM base-dev AS planner
@@ -44,20 +44,20 @@ WORKDIR /app
 COPY --from=planner /app/recipe.json ./
 
 RUN --mount=type=cache,id=target_cache,target=/app/target \
-  cargo chef cook --release --recipe-path recipe.json
+    cargo chef cook --release --recipe-path recipe.json
 
 COPY . .
 
 # Build SP1 ELF to be proven (with optimizations)
-# TODO: need to use `cargo prove --docker` for repoducible builds?
 RUN --mount=type=cache,id=target_cache,target=/app/target \
-  RUSTFLAGS="-Copt-level=3 -Clto=fat -Ccodegen-units=1 -Cdebuginfo=1 -Cembed-bitcode=yes" /root/.sp1/bin/cargo-prove prove build -p chacha-program
+    RUSTFLAGS="-Copt-level=3 -Clto=fat -Ccodegen-units=1 -Cdebuginfo=1 -Cembed-bitcode=yes"\
+    /root/.sp1/bin/cargo-prove prove build --docker -p chacha-program
 # Build the final binary
 # NOTE: default feature is to use --docker ELF
 RUN --mount=type=cache,id=target_cache,target=/app/target \
-  cargo build --release --no-default-features && \
-  strip /app/target/release/pda-proxy && \
-  cp target/release/pda-proxy /app/pda-proxy # pop out of cache
+    cargo build --release && \
+    strip /app/target/release/pda-proxy && \
+    cp target/release/pda-proxy /app/pda-proxy # pop out of cache
 
 ####################################################################################################
 FROM nvidia/cuda:12.9.1-base-ubuntu24.04 AS runtime

--- a/justfile
+++ b/justfile
@@ -51,7 +51,11 @@ run-debug *FLAGS: _pre-build _pre-run
 
 # Build docker image & tag
 docker-build:
-    DOCKER_BUILDKIT=1 docker build --build-arg BUILDKIT_INLINE_CACHE=1 --tag "$DOCKER_CONTAINER_NAME" --progress=plain .
+    DOCKER_BUILDKIT=1 docker build \
+      --build-arg BUILDKIT_INLINE_CACHE=1 \
+      --tag "$DOCKER_CONTAINER_NAME" \
+      --progress=plain \
+      .
 
 # Save docker image to a tar.gz
 docker-save:

--- a/justfile
+++ b/justfile
@@ -74,13 +74,15 @@ docker-run:
     docker run --rm -it \
       -v /var/run/docker.sock:/var/run/docker.sock \
       -v ./service/static:/app/static \
+      -v $HOME/.sp1/circuits:/root/.sp1/circuits \
       -v $PDA_DB_PATH:$PDA_DB_PATH \
       --env-file {{ env-settings }} \
-      --env TLS_CERTS_PATH=/app/static/sample.pem --env TLS_KEY_PATH=/app/static/sample.rsa \
+      --env TLS_CERTS_PATH=/app/static/sample.pem \
+      --env TLS_KEY_PATH=/app/static/sample.rsa \
       --env RUST_LOG=pda_proxy=debug \
       --network=host \
       -p $PDA_PORT:$PDA_PORT \
-      "$DOCKER_CONTAINER_NAME"
+      $DOCKER_CONTAINER_NAME
 
 # Build in debug mode, no optimizations
 build-debug: _pre-build


### PR DESCRIPTION
WIP

> Ultimately, what you’re trying to do—run a full Docker-in-Docker daemon inside a BuildKit build step, cache it, and have it faithfully start up with networking and overlay storage—all in one Dockerfile and one docker build invocation—runs straight into the hard limits of BuildKit’s sandbox and unprivileged container model:
OverlayFS and iptables require root privileges that BuildKit’s docker-container driver won’t grant you.
Bind-mounting /var/run/docker.sock trips BuildKit’s checksum logic.
Running a full dockerd in a BuildKit step will constantly choke on storage and network setup.