### PR TITLE
Private Blockspace (name change from PDA)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4933,7 +4933,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
-name = "pda-proxy"
+name = "pbs-proxy"
 version = "0.3.0"
 dependencies = [
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2024"
 authors = ["Nuke <nuke-web3@proton.me>"]
 license = "MIT"
 homepage = "https://celestia.org"
-repository = "https://github.com/celestiaorg/eq-service"
+repository = "https://github.com/celestiaorg/private-blockspace-proxy"
 
 [workspace.dependencies]
 zkvm-common = { path = "zkVM/common", default-features = false, version = "0.3.0" }

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,8 +56,8 @@ RUN --mount=type=cache,id=target_cache,target=/app/target \
 # Build the final binary, embbeding ELF
 RUN --mount=type=cache,id=target_cache,target=/app/target \
     cargo build --release && \
-    strip /app/target/release/pda-proxy && \
-    cp target/release/pda-proxy /app/pda-proxy # pop out of cache
+    strip /app/target/release/pbs-proxy && \
+    cp target/release/pbs-proxy /app/pbs-proxy # pop out of cache
 
 ####################################################################################################
 FROM nvidia/cuda:12.9.1-base-ubuntu24.04 AS runtime
@@ -65,6 +65,6 @@ FROM nvidia/cuda:12.9.1-base-ubuntu24.04 AS runtime
 # SP1 CUDA support needs Docker-in-Docker to run `moongate-server` prover service
 # Internally run on localhost:3000
 COPY --from=base-dev /usr/bin/docker /usr/bin/docker
-COPY --from=builder /app/pda-proxy /usr/local/bin/pda-proxy
+COPY --from=builder /app/pbs-proxy /usr/local/bin/pbs-proxy
 
-ENTRYPOINT ["/usr/local/bin/pda-proxy"]
+ENTRYPOINT ["/usr/local/bin/pbs-proxy"]

--- a/README.md
+++ b/README.md
@@ -38,16 +38,16 @@ source .env
 # blob.Get
 curl -H "Content-Type: application/json" -H "Authorization: Bearer $CELESTIA_NODE_WRITE_TOKEN" -X POST \
      --data '{ "id": 1, "jsonrpc": "2.0", "method": "blob.Get", "params": [ 4499999, "AAAAAAAAAAAAAAAAAAAAAAAAAFHMGnPWX5X2veY=", "S2iIifIPdAjQ33KPeyfAga26FSF3IL11WsCGtJKSOTA="] }' \
-     $PDA_SOCKET
+     $PBS_SOCKET
 # blob.GetAll
 curl -H "Content-Type: application/json" -H "Authorization: Bearer $CELESTIA_NODE_WRITE_TOKEN" -X POST \
      --data '{ "id": 1, "jsonrpc": "2.0", "method": "blob.GetAll", "params": [ 4499999, [ "AAAAAAAAAAAAAAAAAAAAAAAAAFHMGnPWX5X2veY=" ] ] }' \
-     $PDA_SOCKET
+     $PBS_SOCKET
 # blob.Submit (dummy data)
 # Note: send "{}" as empty `tx_config` object, so the node uses it's default key to sign & submit to Celestia
 curl -H "Content-Type: application/json" -H "Authorization: Bearer $CELESTIA_NODE_WRITE_TOKEN" -X POST \
      --data '{ "id": 1, "jsonrpc": "2.0", "method": "blob.Submit", "params": [ [ { "namespace": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAMJ/xGlNMdE=", "data": "DEADB33F", "share_version": 0, "commitment": "aHlbp+J9yub6hw/uhK6dP8hBLR2mFy78XNRRdLf2794=", "index": -1 } ], { } ] }' \
-     https://$PDA_SOCKET \
+     https://$PBS_SOCKET \
      --verbose \
      --insecure
     # ^^^^ DO NOT use insecure TLS in real scenarios!
@@ -65,17 +65,17 @@ Celestia has many [API client libraries](https://docs.celestia.org/how-to-guides
 ```mermaid
 sequenceDiagram
     participant JSON RPC Client
-    participant PDA Proxy
+    participant PBS Proxy
     participant Celestia Node
-    JSON RPC Client->>+PDA Proxy: blob.Submit(blobs, options)<br>{AUTH_TOKEN in header}
-    PDA Proxy->>PDA Proxy: Job Processing...<br>{If no DB entry, start new zkVM Job}
-    PDA Proxy->>-JSON RPC Client: Response{"Call back"}
-    PDA Proxy->>PDA Proxy: ...Job runs to completion...
-    JSON RPC Client->>+PDA Proxy:  blob.Submit(blobs, options)<br>{AUTH_TOKEN in header}
-    PDA Proxy->>PDA Proxy: Query Job DB<br>Done!<br>{Job Result cached}
-    PDA Proxy->>Celestia Node: blob.Submit(V. Encrypt. blobs, options)
-    Celestia Node->>PDA Proxy: Response{Inclusion Block Height}
-    PDA Proxy->>-JSON RPC Client: Response{Inclusion Block Height}
+    JSON RPC Client->>+PBS Proxy: blob.Submit(blobs, options)<br>{AUTH_TOKEN in header}
+    PBS Proxy->>PBS Proxy: Job Processing...<br>{If no DB entry, start new zkVM Job}
+    PBS Proxy->>-JSON RPC Client: Response{"Call back"}
+    PBS Proxy->>PBS Proxy: ...Job runs to completion...
+    JSON RPC Client->>+PBS Proxy:  blob.Submit(blobs, options)<br>{AUTH_TOKEN in header}
+    PBS Proxy->>PBS Proxy: Query Job DB<br>Done!<br>{Job Result cached}
+    PBS Proxy->>Celestia Node: blob.Submit(V. Encrypt. blobs, options)
+    Celestia Node->>PBS Proxy: Response{Inclusion Block Height}
+    PBS Proxy->>-JSON RPC Client: Response{Inclusion Block Height}
 ```
 
 #### (Try Decrypt) `blob.[Get|GetAll]`
@@ -83,15 +83,15 @@ sequenceDiagram
 ```mermaid
 sequenceDiagram
     participant JSON RPC Client
-    participant PDA Proxy
+    participant PBS Proxy
     participant Celestia Node
 
-    JSON RPC Client->>+PDA Proxy: blob.Get(height, namespace, commitment)
-    PDA Proxy->>Celestia Node: <Passthrough>
-    Celestia Node->>PDA Proxy: Response{namespace,data,<br>share_version,commitment,index}
-    PDA Proxy->>PDA Proxy: *Try* deserialize & decrypt
-    PDA Proxy->>-JSON RPC Client: *Success* -> Response{...,decrypted bytes,...}
-    PDA Proxy->>JSON RPC Client: *Failure* -> <Passthrough>
+    JSON RPC Client->>+PBS Proxy: blob.Get(height, namespace, commitment)
+    PBS Proxy->>Celestia Node: <Passthrough>
+    Celestia Node->>PBS Proxy: Response{namespace,data,<br>share_version,commitment,index}
+    PBS Proxy->>PBS Proxy: *Try* deserialize & decrypt
+    PBS Proxy->>-JSON RPC Client: *Success* -> Response{...,decrypted bytes,...}
+    PBS Proxy->>JSON RPC Client: *Failure* -> <Passthrough>
 ```
 
 #### Transparent Proxy (all other calls)
@@ -99,13 +99,13 @@ sequenceDiagram
 ```mermaid
 sequenceDiagram
     participant JSON RPC Client
-    participant PDA Proxy
+    participant PBS Proxy
     participant Celestia Node
 
-    JSON RPC Client->>+PDA Proxy: Request{<Anything else>}<br>{AUTH_TOKEN in header}
-    PDA Proxy->>Celestia Node: <Passthrough>
-    Celestia Node->>PDA Proxy: <Passthrough>
-    PDA Proxy->>-JSON RPC Client: Response{<Normal API response}
+    JSON RPC Client->>+PBS Proxy: Request{<Anything else>}<br>{AUTH_TOKEN in header}
+    PBS Proxy->>Celestia Node: <Passthrough>
+    Celestia Node->>PBS Proxy: <Passthrough>
+    PBS Proxy->>-JSON RPC Client: Response{<Normal API response}
 ```
 
 ## Operate
@@ -208,16 +208,16 @@ just docker-run
 
 # If you are only running:
 source .env
-mkdir -p $PDA_DB_PATH
+mkdir -p $PBS_DB_PATH
 # Note socket assumes running "normally" with docker managed by root
 docker run --rm -it \
   --user $(id -u):$(id -g) \
   -v /var/run/docker.sock:/var/run/docker.sock \
- -v $PDA_DB_PATH:$PDA_DB_PATH \
+ -v $PBS_DB_PATH:$PBS_DB_PATH \
   --env-file {{ env-settings }} \
-  --env RUST_LOG=pda_proxy=debug \
+  --env RUST_LOG=pbs_proxy=debug \
   --network=host \
-  -p $PDA_PORT:$PDA_PORT \
+  -p $PBS_PORT:$PBS_PORT \
   "$DOCKER_CONTAINER_NAME"
 ```
 
@@ -278,10 +278,10 @@ just docker-run
 
 ## Setup
 source .env
-mkdir -p $PDA_DB_PATH
+mkdir -p $PBS_DB_PATH
 
 ## Run (example)
-[docker|podman] run --rm -it -v $PDA_DB_PATH:$PDA_DB_PATH --env-file .env --env RUST_LOG=eq_service=debug --network=host -p $PDA_PORT:$PDA_PORT pda_proxy
+[docker|podman] run --rm -it -v $PBS_DB_PATH:$PBS_DB_PATH --env-file .env --env RUST_LOG=eq_service=debug --network=host -p $PBS_PORT:$PBS_PORT pbs_proxy
 ```
 
 Importantly, the DB should persist, and the container must have access to connect to the DA light client (likely port 26658) and Succinct network ports (HTTPS over 443).

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Private Data Availability Proxy
+# Private Blockspace Proxy
 
 A [Celestia Data Availability (DA)](https://celestia.org) proxy, enabling use of the [canonical JSON RPC](https://node-rpc-docs.celestia.org/) but intercepting and [**_verifiably_** encrypting](./doc/verifiable_encryption.md) sensitive data before submission on the public DA network, and enable decryption on retrieval.
 Non-sensitive calls are unmodified.
@@ -18,24 +18,11 @@ Presently all HTTP requests to the proxy are transparently proxied to an upstrea
 - `blob.Submit` encrypts before proxy submission of a _signed transaction_ to upstream gRPC `app` endpoint.
 - `blob.Get` and `blob.GetAll` proxy result verifies the [Verifiable Encryption](./doc/verifiable_encryption.md) proof, and decrypts before forwarding to the client.
 
-## Known Limitations
-
-At time of writing, as it should be possible to change these limitations internally:
-
-- [ ] https://github.com/celestiaorg/pda-proxy/issues/11
-- [ ] https://github.com/celestiaorg/pda-proxy/issues/12
-
-It's possible to change these, but requires upstream involvement:
-
-- [Max blob size on Celestia](https://docs.celestia.org/how-to-guides/submit-data#maximum-blob-size) is presently ~2MB
-
-> Please [open an issue](https://github.com/celestiaorg/pda-proxy/issues) if you have any requests!
-
 ## Interact
 
 First you need to [configure](#configure) your environment and nodes.
 
-The PDA proxy depends on a connection to:
+The proxy depends on a connection to:
 
 1. A \[self\] hosted Celestia Data Availability (DA) Node and Consensus App Node to submit and retrieve (verifiable encrypted) blob data.
    - Easy integration with [QuickNode](https://www.quicknode.com/docs/celestia) for both nodes at one endpoint, token auth supported.
@@ -69,7 +56,7 @@ cd scripts
 ./test_example_data_file_via_curl.sh
 ```
 
-Celestia has many [API client libraries](https://docs.celestia.org/how-to-guides/submit-data#api) to build around a PDA proxy.
+Celestia has many [API client libraries](https://docs.celestia.org/how-to-guides/submit-data#api) to build around a proxy.
 
 ### Request Flow
 
@@ -176,10 +163,10 @@ The images are available:
 
 ```sh
 # ghcr:
-docker pull ghcr.io/celestiaorg/pda-proxy
+docker pull ghcr.io/celestiaorg/private-blockspace-proxy
 
 # Docker hub:
-docker pull celestiaorg/pda-proxy
+docker pull celestiaorg/private-blockspace-proxy
 ```
 
 _Don't forget you need to [configure your environment](#configure)_.
@@ -249,8 +236,8 @@ Then:
 1. Clone the repo
 
    ```sh
-   git clone https://github.com/your-repo-name/pda-proxy.git
-   cd pda-proxy
+   git clone https://github.com/your-repo-name/private-blockspace-proxy.git
+   cd private-blockspace-proxy
    ```
 
 1. Choose a Celestia Node

--- a/compose.yml
+++ b/compose.yml
@@ -27,9 +27,9 @@ services:
       retries: 10
       start_period: 3s
 
-  pda-proxy:
+  pbs-proxy:
     image: ghcr.io/celestiaorg/${DOCKER_CONTAINER_NAME}:latest
-    # image: local/pda-proxy # OPTIONAL: for local development
+    # image: local/pbs-proxy # OPTIONAL: for local development
     # build: .  # OPTIONAL: for local development
     depends_on:
       celestia-node:
@@ -37,14 +37,14 @@ services:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       # - ./service/static:/app/static  # OPTIONAL: for local development
-      - ${PDA_DB_PATH}:${PDA_DB_PATH}
+      - ${PBS_DB_PATH}:${PBS_DB_PATH}
       - /etc/letsencrypt/live/${TLS_DOMAIN}/fullchain.pem:/etc/letsencrypt/live/${TLS_DOMAIN}/fullchain.pem
       - /etc/letsencrypt/live/${TLS_DOMAIN}/privkey.pem:/etc/letsencrypt/live/${TLS_DOMAIN}/privkey.pem
     environment:
       # NOTE: Overrides any .env settings
       - TLS_CERTS_PATH=/etc/letsencrypt/live/${TLS_DOMAIN}/fullchain.pem
       - TLS_KEY_PATH=/etc/letsencrypt/live/${TLS_DOMAIN}/privkey.pem
-      - RUST_LOG=pda_proxy=debug
+      - RUST_LOG=pbs_proxy=debug
       # docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' celestia-light-mocha-4
       - CELESTIA_NODE_SOCKET=172.18.0.2:26658
     env_file:
@@ -52,7 +52,7 @@ services:
     networks:
       - internal
     ports:
-      - "443:${PDA_PORT}"  # Public HTTPS
+      - "443:${PBS_PORT}"  # Public HTTPS
     restart: unless-stopped
 
 networks:

--- a/doc/verifiable_encryption.md
+++ b/doc/verifiable_encryption.md
@@ -1,4 +1,4 @@
-<h1 align="center"> Verifiable Encryption</h1>
+<h1 align="center">Verifiable Encryption</h1>
 
 <p align="center">
   <a href="https://www.youtube.com/watch?v=6P7yWZ4Cshs">
@@ -13,7 +13,7 @@
 
 > “Don’t trust. Verify.”
 
-This document introduces **Verifiable Encryption (VE)** and explores how it enables **Private Data Availability (PDA)** - a transformative new primitive for secure, decentralized systems.
+This document introduces **Verifiable Encryption (VE)** and explores how it enables **Private Blockspace** - a transformative new primitive for accountable, offchain systems.
 
 ## Verifiable Encryption
 
@@ -43,9 +43,9 @@ However, not all data should be exposed to the world.
 Some datasets are **too sensitive** for full transparency.
 The challenge: **How can we ensure critical data is available, yet only selectively disclosed under prearranged conditions**?
 
-## The Power of VE + PDA
+## The Power of VE
 
-By combining **Verifiable Encryption** with **Private Data Availability**, we unlock a powerful new primitive: **auditable yet private data**.
+By combining **Verifiable Encryption** with **Private Blockspace**, we unlock a powerful new primitive: **auditable yet private data**.
 
 With integration into **existing or novel Key Management Systems (KMS)**, VE allows one to define:
 
@@ -55,30 +55,30 @@ With integration into **existing or novel Key Management Systems (KMS)**, VE all
 
 This means:
 
-- Anyone (users, smart contracts, off-chain agents) can verify that encrypted data is available and satisfies certain properties.
+- Anyone (users, smart contracts, offchain agents) can verify that encrypted data is available and satisfies certain properties.
 - Only authorized parties can decrypt and access the sensitive contents.
 
 ## Use Cases
 
 We’ve outlined a few use cases below - but would love to hear your ideas too!
-💡 [Open an issue](https://github.com/celestiaorg/pda-proxy/issues) to share feature requests or novel applications of VE and PDA.
+💡 [Open an issue](https://github.com/celestiaorg/private-blockspace-proxy/issues) to share feature requests or novel applications of Private Blockspace.
 
 ### _Programmable Privacy for Web3 dApps_
 
-VE and PDA align closely with the principles of [local-first access control](https://www.inkandswitch.com/keyhive/notebook/), enabling **secure collaboration** across decentralized applications.
+VE and Private Blockspace align closely with the principles of [local-first access control](https://www.inkandswitch.com/keyhive/notebook/), enabling **secure collaboration** across decentralized applications.
 
 In a world where chain data is globally replicated and indexed, **encryption at rest** becomes essential for access control and selective disclosure.
 
 #### Example Applications
 
-- **PDA as a database** for collaborative dApps with fine-grained access control.
+- **VE'd database** for collaborative dApps with fine-grained access control.
 - **Private rollups** with programmable cryptography, enabling [obfuscated state](https://0xparc.org/blog/programmable-cryptography-1).
 - **Private bridging and escrow** sending verifiably correct but private messages around web2 and/or web3 apps.
-- **Drop-in support** for existing DA users via a [proxy service](../README.md), simplifying migration to PDA.
+- **Drop-in support** for existing DA users via a [proxy service](../README.md), simplifying migration to Private Blockspace.
 
 ### _Trustless Data Markets_
 
-With VE, PDA, and escrow contracts you can construct protocols to build trustless exchange of data access
+With VE, Private Blockspace, and escrow contracts you can construct protocols to build trustless exchange of data access
 See the [Stock0](https://dorahacks.io/buidl/14098) media market hackathon project for some great inspiration!
 
 Here is a [diagram inspired by them](https://docs.google.com/presentation/d/1qq1QXSBcThOjaQ2OcEyS8cwNyAHs3SnC76YrBMAYENk) of an example setup of inputs for a market:
@@ -97,7 +97,7 @@ flowchart LR
 > NOTE: Celestia does _not_ guarantee that data will be available forever!
 > See [the docs on retrievability](https://docs.celestia.org/learn/retrievability#data-retrievability-and-pruning-in-celestia-node) for the latest safe assumptions to use.
 
-With PDA, sensitive data can be publicly published in encrypted form, with **predefined methods for recovery** - without revealing its contents.
+With Private Blockspace, sensitive data can be publicly published in encrypted form, with **predefined methods for recovery** - without revealing its contents.
 
 This unlocks a new class of **verifiable, resilient backups**.
 
@@ -115,13 +115,16 @@ The **anchor** acts as a bridge, connecting **any protocol** to a **proof** that
 
 ## Future Work and Research Directions
 
-While VE for PDA is still evolving, the potential is enormous.
+While VE for Private Blockspace is still evolving, the potential is enormous.
 Current implementations have limitations, but these are rapidly being addressed by:
 
-- Enabling performance improvements, **confidential compute**, and **scalable parallelization** of PDA workflows.
+- Enabling performance improvements, **confidential compute**, and **scalable parallelization** of Private Blockspace workflows.
 - **Hybrid systems** combining:
   - Trusted Execution Environments (TEEs),
   - Multi-Party Computation (MPC),
   - and Zero-Knowledge Proofs (ZKPs),
+- **Account-centric key management systems** empowering end-users to declare keys to use for VE by operators.
 
-For deeper insights, see our ongoing [research discussion here](https://docs.google.com/document/d/1XZyuOxdMm5INcHwQZOZ8ALRk_YkvicNwQHSfOVs8hoM/).
+For more, see:
+- [(Historical) research document](https://docs.google.com/document/d/1XZyuOxdMm5INcHwQZOZ8ALRk_YkvicNwQHSfOVs8hoM/)
+- [Account-centric model for Private Blockspace research discussion](https://forum.celestia.org/t/account-user-centric-private-data-avalibility/2155/)

--- a/example.env
+++ b/example.env
@@ -29,8 +29,8 @@ TLS_DOMAIN="your.domain.com"
 TLS_CERTS_PATH=
 TLS_KEY_PATH=
 # ONLY for development, you may use dummy TLS setup from source ./service/static
-# TLS_CERTS_PATH=/full/path/to/pda-proxy/service/static/sample.pem
-# TLS_KEY_PATH=/full/path/to/pda-proxy/service/static/sample.rsa
+# TLS_CERTS_PATH=/full/path/to/pbs-proxy/service/static/sample.pem
+# TLS_KEY_PATH=/full/path/to/pbs-proxy/service/static/sample.rsa
  
 #### Service Settings
 
@@ -40,17 +40,17 @@ TLS_KEY_PATH=
 # UNSAFE_HTTP_UPSTREAM=true # comment this out or unset to force https
 
 # More info on docker in README.md
-# https://github.com/nuke-web3/pda-proxy/
-DOCKER_CONTAINER_NAME="ghcr.io/celestiaorg/pda-proxy"
+# https://github.com/celestiaorg/private-blockspace-proxy
+DOCKER_CONTAINER_NAME="ghcr.io/celestiaorg/pbs-proxy"
 
-PDA_DB_PATH=/tmp/db-pda-service-testing
+PBS_DB_PATH=/tmp/db-pbs-service-testing
 # 32 byte key used for ChaCha20 encryption
 ENCRYPTION_KEY=
 # Expects a socket with ip & port specified (not transport)
 # NOTE: 0.0.0.0 binding will allow the service to be accessible to inbound
-PDA_SOCKET=0.0.0.0:26657
+PBS_SOCKET=0.0.0.0:26657
 # Explicit port for docker (can't compute with --env-file)
-PDA_PORT=26657
+PBS_PORT=26657
 
 #### ZK Proof Settings
 

--- a/justfile
+++ b/justfile
@@ -47,16 +47,16 @@ bench-cycles *FLAGS: _pre-build _pre-run
 
 # Run in release mode, zkVM ELF stable with optimizations AND debug logs
 run-release-reproducible *FLAGS: _pre-build-reproducible _pre-run
-    RUST_LOG=pda_proxy=debug cargo r -r --features reproducible-elf -- {{ FLAGS }}
+    RUST_LOG=pbs_proxy=debug cargo r -r --features reproducible-elf -- {{ FLAGS }}
 
 # Run in release mode, with optimizations AND debug logs
 run-release *FLAGS: _pre-build _pre-run
-    RUST_LOG=pda_proxy=debug cargo r -r -- {{ FLAGS }}
+    RUST_LOG=pbs_proxy=debug cargo r -r -- {{ FLAGS }}
 
 # Run in debug mode, with extra pre-checks, no optimizations
 run-debug *FLAGS: _pre-build _pre-run
     # TODO :Check DA node up with some healthcheck endpoint
-    RUST_LOG=pda_proxy=debug cargo r -- {{ FLAGS }}
+    RUST_LOG=pbs_proxy=debug cargo r -- {{ FLAGS }}
 
 # Build docker image & tag
 docker-build:
@@ -76,7 +76,7 @@ docker-load:
 
 # Run a pre-built docker image
 docker-run:
-    mkdir -p $PDA_DB_PATH
+    mkdir -p $PBS_DB_PATH
     # Note socket assumes running "normally" with docker managed by root
     # TODO: support docker rootless!
     # FIXME: files with relative paths accross .env file!
@@ -84,13 +84,13 @@ docker-run:
       -v /var/run/docker.sock:/var/run/docker.sock \
       -v ./service/static:/app/static \
       -v $HOME/.sp1/circuits:/root/.sp1/circuits \
-      -v $PDA_DB_PATH:$PDA_DB_PATH \
+      -v $PBS_DB_PATH:$PBS_DB_PATH \
       --env-file {{ env-settings }} \
       --env TLS_CERTS_PATH=/app/static/sample.pem \
       --env TLS_KEY_PATH=/app/static/sample.rsa \
-      --env RUST_LOG=pda_proxy=debug \
+      --env RUST_LOG=pbs_proxy=debug \
       --network=host \
-      -p $PDA_PORT:$PDA_PORT \
+      -p $PBS_PORT:$PBS_PORT \
       $DOCKER_CONTAINER_NAME
 
 # Build in debug mode, no optimizations
@@ -169,7 +169,7 @@ celestia-node-balance:
 
 # https://mocha-4.celenium.io/tx/28fa01d026ac5a229e5d5472a204d290beda02ea229f6b3f42da520b00154e58?tab=messages
 
-# Test blob.Get for PDA Proxy
+# Test blob.Get for PBS Proxy
 curl-blob-get:
     curl -H "Content-Type: application/json" -H "Authorization: Bearer $CELESTIA_NODE_WRITE_TOKEN" --data '{"id": 1,"jsonrpc": "2.0", "method": "blob.Get", "params": [ 6629478, "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAMJ/xGlNMdE=", "yS3XX33mc1uXkGinkTCvS9oqE0k9mtHMWTz0mwZccOc=" ] }' \
     https://127.0.0.1:26657 \
@@ -184,7 +184,7 @@ curl-blob-get-passthrough:
 
 # https://mocha.celenium.io/tx/436f223bfa8c4adf1e1b79dde43a84918f3a50809583c57c33c1c079568b47cb?tab=messages
 
-# Test blob.Submit for PDA proxy, max gas price is minimum 0.0004utia
+# Test blob.Submit for PBS proxy, max gas price is minimum 0.0004utia
 curl-blob-submit-with-max-gas:
     curl -H "Content-Type: application/json" \
          -H "Authorization: Bearer $CELESTIA_NODE_WRITE_TOKEN" \

--- a/scripts/test_example_data_file_via_curl.sh
+++ b/scripts/test_example_data_file_via_curl.sh
@@ -13,4 +13,4 @@ source ../.env
         --data @- https://$TLS_DOMAIN --verbose # remote on 443
 
 # | curl -H "Content-Type: application/json" -H "Authorization: Bearer $CELESTIA_NODE_WRITE_TOKEN" \
-#          --data @- https://$PDA_SOCKET --verbose --insecure # local
+#          --data @- https://$PBS_SOCKET --verbose --insecure # local

--- a/service/Cargo.toml
+++ b/service/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "pda-proxy"
+name = "pbs-proxy"
 version.workspace = true
 edition.workspace = true
 

--- a/service/src/internal/error.rs
+++ b/service/src/internal/error.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 #[derive(Clone, Error, Serialize, Deserialize)]
-pub enum PdaRunnerError {
+pub enum PbsRunnerError {
     #[error("Service: {0}")]
     InternalError(String),
 
@@ -19,13 +19,13 @@ pub enum PdaRunnerError {
 }
 
 // This removes a layer of escape chars for json formatting
-impl fmt::Debug for PdaRunnerError {
+impl fmt::Debug for PbsRunnerError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            PdaRunnerError::InternalError(s) => write!(f, "InternalError({s})"),
-            PdaRunnerError::ZkClientError(s) => write!(f, "ZkClientError({s})"),
-            PdaRunnerError::DaClientError(s) => write!(f, "DaClientError({s})"),
-            PdaRunnerError::InvalidParameter(s) => write!(f, "InvalidParameter({s})"),
+            PbsRunnerError::InternalError(s) => write!(f, "InternalError({s})"),
+            PbsRunnerError::ZkClientError(s) => write!(f, "ZkClientError({s})"),
+            PbsRunnerError::DaClientError(s) => write!(f, "DaClientError({s})"),
+            PbsRunnerError::InvalidParameter(s) => write!(f, "InvalidParameter({s})"),
         }
     }
 }

--- a/service/src/internal/job.rs
+++ b/service/src/internal/job.rs
@@ -1,6 +1,6 @@
 use core::fmt;
 
-use crate::PdaRunnerError;
+use crate::PbsRunnerError;
 
 use serde::{Deserialize, Serialize};
 use sp1_sdk::SP1ProofWithPublicValues;
@@ -44,7 +44,7 @@ impl fmt::Debug for Anchor {
     }
 }
 
-/// Used as a [Job] state machine for the PDA service.
+/// Used as a [Job] state machine for the PBS service.
 #[derive(Serialize, Deserialize)]
 pub enum JobStatus {
     /// A ZK prover job had been started, awaiting completion
@@ -58,10 +58,10 @@ pub enum JobStatus {
     // Ideally we only want the public values + whatever is needed to verify the proof
     // They don't seem to provide a type for that.
     ZkProofFinished(SP1ProofWithPublicValues),
-    /// A wrapper for any [PdaServiceError], with:
+    /// A wrapper for any [PbsRunnerError], with:
     /// - Option = None                        --> Permanent failure
     /// - Option = Some(\<retry-able status\>) --> Retry is possible, with a JobStatus state to retry with
-    Failed(PdaRunnerError, Option<Box<JobStatus>>),
+    Failed(PbsRunnerError, Option<Box<JobStatus>>),
 }
 
 impl std::fmt::Debug for JobStatus {

--- a/service/src/internal/util.rs
+++ b/service/src/internal/util.rs
@@ -129,7 +129,7 @@ pub fn json_response(body: Value, status: StatusCode) -> Response<StreamBody> {
 }
 
 pub fn pending_response() -> Response<StreamBody> {
-    let raw_json = r#"{ "id": 1, "jsonrpc": "2.0", "status": "[pda-proxy] Verifiable encryption processing... Call back for result" }"#;
+    let raw_json = r#"{ "id": 1, "jsonrpc": "2.0", "status": "[pbs-proxy] Verifiable encryption processing... Call back for result" }"#;
     new_response_from(raw_json, StatusCode::ACCEPTED)
 }
 
@@ -137,7 +137,7 @@ pub fn internal_error_response(error: &str) -> Response<StreamBody> {
     let json_obj = json!({
         "id": 1,
         "jsonrpc": "2.0",
-        "error": { "message": format!("[pda-proxy] internal error: {}", error) }
+        "error": { "message": format!("[pbs-proxy] internal error: {}", error) }
     });
     json_response(json_obj, StatusCode::INTERNAL_SERVER_ERROR)
 }

--- a/zkVM/sp1/justfile
+++ b/zkVM/sp1/justfile
@@ -66,12 +66,12 @@ build-elf-reproducible:
 
 # Run the proxy in release mode with debug logs
 run-release *FLAGS: build-elf
-    RUST_LOG=pda_proxy=debug cargo r -r -- {{ FLAGS }}
+    RUST_LOG=pbs_proxy=debug cargo r -r -- {{ FLAGS }}
 
 # Run the proxy in debug mode
 run-debug *FLAGS: build-elf
     # TODO: Add node healthcheck (e.g., curl local /health endpoint)
-    RUST_LOG=pda_proxy=debug cargo r -- {{ FLAGS }}
+    RUST_LOG=pbs_proxy=debug cargo r -- {{ FLAGS }}
 
 # Print the zkVM program viewkey (vkey)
 print-viewkey *FLAGS: build-elf


### PR DESCRIPTION
Renaming to "Private Blockspace" and "PBS" where appropriate from private data availability (PDA)

### NOTE: BREAKING CHANGE

- env variable names, should be a simple find&replace for `PDA_` to `PBS_`. 
- docker package name to be published at `pbs-proxy` from here on.